### PR TITLE
Change priority order of XacmlBasedAuthorizationHandler

### DIFF
--- a/components/org.wso2.carbon.identity.application.authz.xacml/src/main/java/org/wso2/carbon/identity/application/authz/xacml/handler/impl/XACMLBasedAuthorizationHandler.java
+++ b/components/org.wso2.carbon.identity.application.authz.xacml/src/main/java/org/wso2/carbon/identity/application/authz/xacml/handler/impl/XACMLBasedAuthorizationHandler.java
@@ -290,6 +290,19 @@ public class XACMLBasedAuthorizationHandler extends AbstractPostAuthnHandler {
         }
     }
 
+    @Override
+    public int getPriority() {
+
+        int priority = super.getPriority();
+        if (priority == -1) {
+            /* Priority value should be greater than PostAuthAssociationHandler, so that JIT provisioned users
+             * username will be correctly adjusted when executing XACMLBasedAuthorizationHandler.
+             */
+            priority = 26;
+        }
+        return priority;
+    }
+
     private String[] getAttributeValues(String attributes) {
 
         return attributes.split(FrameworkUtils.getMultiAttributeSeparator());


### PR DESCRIPTION
Purpose
Change the priority order of XACMLBasedAuthorizationHandler to be a higher value than of PostAuthAssociationHandler[1]

Related Issues:
https://github.com/wso2/product-is/issues/13709

[1] https://github.com/wso2/carbon-identity-framework/blob/72d98ff1514132f20ba9bc898d6185688d50899e/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/PostAuthAssociationHandler.java#L81